### PR TITLE
Updated WSL Remote Status Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 12.2.2 [WSL Button Usability]
+
+- Updated the WSL remote button in the status bar to be more visible.
+
 # 12.2.1 [Text Link Consistency]
 
 - Updated the text link color for all themes to be conistent with the other platforms' text link color.

--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -109,6 +109,8 @@
     "tab.activeBorder": "&accentColor&",
     "peekView.border": "&accentColor&",
     "statusBar.background": "&accentColor&",
+    "statusBarItem.remoteBackground": "&selectionBackground&",
+    "statusBarItem.remoteForeground": "&selectionForeground&",
     "statusBar.noFolderBackground": "&accentColor&",
     "panelTitle.activeBorder": "&accentColor&",
     "statusBar.debuggingBackground": "&accentColor&",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "A bunch of themes with cute anime girls. Code with your waifu!",
   "publisher": "unthrottled",
-  "version": "12.2.1",
+  "version": "12.2.2",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from "./VSCodeGlobals";
 import { attemptToGreetUser } from "./WelcomeService";
 
 const SAVED_VERSION = "doki.theme.version";
-const DOKI_THEME_VERSION = "v12.2.1";
+const DOKI_THEME_VERSION = "v12.2.2";
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
   const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Changed the WSL Button to be the color of the theme's selection

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Most other themes (that I have on my machine), have the WSL button as high contrast. So Figured this would work too.

Fixes #79 

#### Screenshots (if appropriate):

Before: Left. After: Right

![image](https://user-images.githubusercontent.com/15972415/121262910-7cc85080-c87a-11eb-8de6-c121b9009df5.png)


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
