### PR TITLE
Replaces reload prompts with quit for asset changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ _Zero Two's Not Just A Cutie. ;)_
 
 - Added the ability to control the position & size of the sticker using the `doki.sticker.css` configruation property.
 - Fixed artifacted background images on the extension list tree & settings UI selected config (be sure to re-install your wallpaper for this to take effect).
-- Restored asset installation on code-server (please be sure to clear caches and hard reload!)
+- Restored asset installation on code-server (please be sure to clear caches and hard restart!)
 - Added Remote Development Server/SSH connection asset installation help instructions.
 
 # 84.2-1.2.1 [Small Dart Enhancement]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Steps demonstrated:
 1. Choose Ryuko's Color Theme
 1. Enable Ryuko's wallpaper
-1. Reload/Restart VSCode
+1. Restart VSCode
 1. Demonstrate glass pane feature
 
 ## Screen Samples!
@@ -79,21 +79,28 @@ You can choose themes based on characters from these various Anime, Manga, or Vi
 
 # Documentation
 
+- [Theme Preview](#theme-preview)
+- [Feature Preview](#feature-preview)
+  - [Screen Samples!](#screen-samples)
+- [Complete Theme Album.](#complete-theme-album)
+  - [About!](#about)
+- [Documentation](#documentation)
 - [Configuration](#configuration)
-    - [Background Images](#background-images)
-    - [Hide VSCode Watermark](#hide-watermark)
-    - [Stickers](#sticker)
-    - [Custom Assets](#custom-assets)
-    - [Asset Restoration](#asset-restoration)
-    - [Suggestive Content](#suggestive-content)
-    - [Asset Removal](#remove-assets)
-    - [Show Changelog](#show-changelog)
+  - [Background Images](#background-images)
+      - [Settings](#settings)
+  - [Hide Watermark](#hide-watermark)
+  - [Stickers](#stickers)
+  - [Custom Assets](#custom-assets)
+  - [Asset Restoration](#asset-restoration)
+  - [Suggestive Content](#suggestive-content)
+  - [Remove Assets](#remove-assets)
+  - [Show Changelog](#show-changelog)
 - [Miscellaneous](#miscellaneous)
-    - [Contributing](#contributing)
-    - [Theme Requests](#theme-requests)
-    - [Helping the community](#enjoying-the-plugin)
-    - [Feature Requests](#contributions)
-    - [More Doki Theme!](#even-more-doki-theme)
+  - [Contributing](#contributing)
+  - [Theme Requests](#theme-requests)
+  - [Enjoying the plugin?](#enjoying-the-plugin)
+  - [Contributions?](#contributions)
+  - [Even more Doki-Theme!](#even-more-doki-theme)
 
 # Configuration
 

--- a/src/ThemeManager.ts
+++ b/src/ThemeManager.ts
@@ -30,7 +30,7 @@ export const ACTIVE_THEME = "doki.theme.active";
 export const ACTIVE_STICKER = "doki.sticker.active";
 
 const FIRST_TIME_STICKER_INSTALL = "doki.sticker.first.install";
-export const handleInstallMessage = `Quick reload to see changes, please restart VSCode to remove the Unsupported warning.`
+export const handleInstallMessage = `Restart to see changes, please restart VSCode to remove the Unsupported warning.`
 
 const createCulturedInstall = (themeId: string): string =>
   `doki.cultured.${themeId}`;
@@ -205,7 +205,7 @@ export function activateHideWatermark(
   );
 }
 
-const quickReloadAction = "Quickly Reload Window";
+const QuitAction = "Quit";
 
 export function activateThemeAsset(
   dokiTheme: DokiTheme,
@@ -259,11 +259,11 @@ export function showInstallNotification(message: string) {
   vscode.window
     .showInformationMessage(
       message,
-      { title: quickReloadAction }
+      { title: QuitAction }
     )
     .then((item) => {
       if (item) {
-        vscode.commands.executeCommand("workbench.action.reloadWindow");
+        vscode.commands.executeCommand("workbench.action.quit");
       }
     });
 }
@@ -287,11 +287,11 @@ export function uninstallImages(context: vscode.ExtensionContext) {
     vscode.window
       .showInformationMessage(
         `Removed All Images. ${handleInstallMessage}`,
-        { title: quickReloadAction }
+        { title: QuitAction }
       )
       .then((item) => {
         if (item) {
-          vscode.commands.executeCommand("workbench.action.reloadWindow");
+          vscode.commands.executeCommand("workbench.action.quit");
         }
       });
   } else if (stickersRemoved === InstallStatus.FAILURE) {

--- a/src/WelcomeService.ts
+++ b/src/WelcomeService.ts
@@ -100,7 +100,7 @@ export function attemptToGreetUser(context: vscode.ExtensionContext) {
                 <ol>
                     <li>Choose Color Theme</li>
                     <li>Enable Theme's Stickers</li>
-                    <li>Reload/Restart VSCode</li>
+                    <li>Restart VSCode</li>
                     <li>Code!</li>
                 </ol> 
             </div>


### PR DESCRIPTION
Updates user guidance and notifications to prompt for quitting VSCode instead of reloading the window after asset installation or removal. Aims to reduce unsupported warning persistence and improve clarity for users, aligning documentation and UI with the new flow.

#### Description
This pull request focuses on improving the user experience by clarifying instructions and updating the terminology around restarting VSCode. It also reorganizes and enhances the documentation structure for better readability. The most significant changes are:

**User Experience Improvements:**

* Updated all user-facing instructions and notifications to consistently use "Restart VSCode" or "Restart" instead of "Reload/Restart VSCode" or "Quick reload," making the process clearer for users. This includes changes in the `README.md`, `CHANGELOG.md`, notification messages, and onboarding instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[2]](diffhunk://#diff-d812b35caa98e4200211569c279d1c18c60fe42900750e836216430efd6aa936L33-R33) [[3]](diffhunk://#diff-d812b35caa98e4200211569c279d1c18c60fe42900750e836216430efd6aa936L208-R208) [[4]](diffhunk://#diff-d812b35caa98e4200211569c279d1c18c60fe42900750e836216430efd6aa936L262-R266) [[5]](diffhunk://#diff-d812b35caa98e4200211569c279d1c18c60fe42900750e836216430efd6aa936L290-R294) [[6]](diffhunk://#diff-bdb721e79499b01440ce20931dcd05b45e6f02ab6b56b6676b1b22253e580abbL103-R103) [[7]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL89-R89)

**Documentation Enhancements:**

* Reorganized and expanded the documentation in `README.md` by adding new sections, improving the table of contents, and clarifying configuration and miscellaneous options. This makes it easier for users to find relevant information and understand the available features.



#### Motivation and Context
Fixes https://github.com/doki-theme/doki-theme-vscode/issues/269 and https://github.com/doki-theme/doki-theme-vscode/issues/263

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-Functional Change (non-user facing changes)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I updated the version.
- [ ] I updated the changelog with the new functionality.

I can update changelog but I need to know what version will be next as there is no [Unreleased] entry
